### PR TITLE
adding in search job messages call to sumologic

### DIFF
--- a/lib/sumologic.rb
+++ b/lib/sumologic.rb
@@ -52,6 +52,14 @@ module SumoLogic
       end
     end
 
+    def search_job_messages(search_job, limit=nil, offset=0)
+      params = {:limit => limit, :offset => offset}
+      r = @session.get do |req|
+        req.url "search/jobs/#{search_job['id']}/messages"
+        req.params = params
+      end
+    end
+
     def dashboards(monitors=false)
       params = {dashboards: monitors}
       r = @session.get do |req|


### PR DESCRIPTION
I needed to add this additional API call for some work I've been doing.  I couldn't really see a way to easily put any tests in for it.  Though it is such a thin facade above the API the tests may have little value anyway.
